### PR TITLE
golangci-lint, go fmt, fullword names

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 
 func main() {
 	var (
-		greatestFlag  bool
-		leastFlag     bool
-		constraint string
+		greatestFlag bool
+		leastFlag    bool
+		constraint   string
 	)
 
 	flag.BoolVar(&greatestFlag, "greatest", false, "display the greatest version for a given list")

--- a/main.go
+++ b/main.go
@@ -13,24 +13,24 @@ import (
 
 func main() {
 	var (
-		fgreatest  bool
-		fleast     bool
+		greatestFlag  bool
+		leastFlag     bool
 		constraint string
 	)
 
-	flag.BoolVar(&fgreatest, "greatest", false, "display the greatest version for a given list")
-	flag.BoolVar(&fleast, "least", false, "display the least version for a given list")
+	flag.BoolVar(&greatestFlag, "greatest", false, "display the greatest version for a given list")
+	flag.BoolVar(&leastFlag, "least", false, "display the least version for a given list")
 	flag.StringVar(&constraint, "constraint", "", "list versions greatest to least, if versions pass given constraint.")
 
 	flag.Parse()
 
-	if fgreatest == false && fleast == false && constraint == "" {
+	if !greatestFlag && !leastFlag && constraint == "" {
 		flag.Usage()
 		os.Exit(0)
 	}
 
 	reader := bufio.NewReader(os.Stdin)
-	var rawvers []string
+	var rawVersions []string
 
 	for {
 		input, _, err := reader.ReadLine()
@@ -41,31 +41,31 @@ func main() {
 			os.Exit(1)
 		}
 
-		rawvers = append(rawvers, string(input))
+		rawVersions = append(rawVersions, string(input))
 	}
 
-	vers := make([]*semver.Version, len(rawvers))
+	versions := make([]*semver.Version, len(rawVersions))
 
-	for i, r := range rawvers {
+	for i, r := range rawVersions {
 		v, err := semver.NewVersion(r)
 		if err != nil {
 			fmt.Printf("Error parsing version '%s': %s\n", r, err.Error())
 			os.Exit(2)
 		}
 
-		vers[i] = v
+		versions[i] = v
 	}
 
 	// greatest to least
-	sort.Sort(sort.Reverse(semver.Collection(vers)))
+	sort.Sort(sort.Reverse(semver.Collection(versions)))
 
-	if fgreatest {
-		fmt.Println(vers[0])
+	if greatestFlag {
+		fmt.Println(versions[0])
 		os.Exit(0)
 	}
 
-	if fleast {
-		fmt.Println(vers[len(vers)-1])
+	if leastFlag {
+		fmt.Println(versions[len(versions)-1])
 		os.Exit(0)
 	}
 
@@ -75,9 +75,9 @@ func main() {
 			fmt.Printf("Error parsing constraint '%s': %s\n", constraint, err.Error())
 			os.Exit(3)
 		}
-		for _, v := range vers {
+		for _, v := range versions {
 			status, _ := c.Validate(v)
-			if status == true {
+			if status {
 				fmt.Println(v)
 			}
 		}


### PR DESCRIPTION
A couple of nitpick readability conventions for your consideration.